### PR TITLE
Ensure imputation warnings are only shown under the right conditions

### DIFF
--- a/R/confirm.R
+++ b/R/confirm.R
@@ -222,13 +222,17 @@ confirm <- function(Y, hypothesis,
                     impute = TRUE,
                     seed = NULL, ...){
 
-
-  # temporary warning until missing data is fully implemented
-  if(type != "continuous"){
-    warning(paste0("imputation during model fitting is\n",
-                   "currently only implemented for 'continuous' data."))
+  # Temporarily, if the type is not in an allowed set.
+  if (!type %in% c("continuous")) {
+    # And the user wants to impute.
+    if (impute) {
+        # Warn them politely.
+        warning(paste0(
+            "imputation during model fitting is\n",
+            "currently only implemented for 'continuous' data."
+        ))
+    }
   }
-
 
   set.seed(seed)
   ## Random seed unless user provided
@@ -690,5 +694,3 @@ print_confirm <- function(x, ...){
 
   cat("note: equal hypothesis prior probabilities")
 }
-
-

--- a/R/estimate.R
+++ b/R/estimate.R
@@ -210,13 +210,15 @@ estimate  <- function(Y,
                       seed = NULL,
                       ...){
 
-  # temporary warning until missing data is fully implemented
-  if(!type %in% c("continuous", "mixed")){
-
-    if(impute){
-    warning(paste0("imputation during model fitting is\n",
-                   "currently only implemented for 'continuous'
-                    and 'mixed' data."))
+  # Temporarily, if the type is not in an allowed set.
+  if (!type %in% c("continuous", "mixed")) {
+    # And the user wants to impute.
+    if (impute) {
+        # Warn them politely.
+        warning(paste0(
+            "imputation during model fitting is\n",
+            "currently only implemented for 'continuous' and 'mixed' data."
+        ))
     }
   }
 

--- a/R/explore.default.R
+++ b/R/explore.default.R
@@ -173,14 +173,15 @@ explore <- function(Y,
                     impute = FALSE,
                     seed = NULL, ...){
 
-  # temporary warning until missing data is fully implemented
-  if(!type %in% c("continuous", "mixed")){
-
-    if(impute){
-
-      warning(paste0("imputation during model fitting is\n",
-                   "currently only implemented for 'continuous'
-                   and 'mixed' data."))
+  # Temporarily, if the type is not in an allowed set.
+  if (!type %in% c("continuous", "mixed")) {
+    # And the user wants to impute.
+    if (impute) {
+        # Warn them politely.
+        warning(paste0(
+            "imputation during model fitting is\n",
+            "currently only implemented for 'continuous' and 'mixed' data."
+        ))
     }
   }
 

--- a/R/ggm_compare_confirm.R
+++ b/R/ggm_compare_confirm.R
@@ -342,12 +342,16 @@ ggm_compare_confirm <- function(...,
                                 progress = TRUE,
                                 seed = NULL){
 
-
-
-  # temporary warning until missing data is fully implemented
-  if(type != "continuous"){
-    warning(paste0("imputation during model fitting is\n",
-                   "currently only implemented for 'continuous' data."))
+  # Temporarily, if the type is not in an allowed set.
+  if (!type %in% c("continuous")) {
+    # And the user wants to impute.
+    if (impute) {
+        # Warn them politely.
+        warning(paste0(
+            "imputation during model fitting is\n",
+            "currently only implemented for 'continuous' data."
+        ))
+    }
   }
 
   set.seed(seed)
@@ -1082,4 +1086,3 @@ plot.confirm <- function(x, ...){
   plt
 
 }
-

--- a/R/ggm_compare_estimate.default.R
+++ b/R/ggm_compare_estimate.default.R
@@ -198,10 +198,16 @@ ggm_compare_estimate <- function(...,
                                  progress = TRUE,
                                  seed = 1){
 
-  # temporary warning until missing data is fully implemented
-  if(type != "continuous"){
-    warning(paste0("imputation during model fitting is\n",
-                   "currently only implemented for 'continuous' data."))
+  # Temporarily, if the type is not in an allowed set.
+  if (!type %in% c("continuous")) {
+    # And the user wants to impute.
+    if (impute) {
+        # Warn them politely.
+        warning(paste0(
+            "imputation during model fitting is\n",
+            "currently only implemented for 'continuous' data."
+        ))
+    }
   }
 
   # combine data


### PR DESCRIPTION
I noticed when performing some comparisons that the package issues the following imputation-related warning:

```txt
Warning message:
In (function (..., formula = NULL, type = "continuous", mixed_type = NULL,  :
  imputation during model fitting is
currently only implemented for 'continuous' data.
```

despite the `type` being explicitly specified as `"ordinal"`. This was not the case, e.g., when using `BGGM::estimate`.

The goal of this PR is to address this issue (i.e., #96) by ensuring that the imputation warnings are only displayed when not supported.