### PR TITLE
Update bggm_missing.R removing .imp column by name

### DIFF
--- a/R/bggm_missing.R
+++ b/R/bggm_missing.R
@@ -102,7 +102,7 @@ bggm_missing <- function(x, iter = 2000,
   if(method == "explore"){
 
     # fit the models
-    fits <- lapply(1:n_data_sets, function(x) explore(as.matrix(subset(Y, .imp == x)[,-1]),
+    fits <- lapply(1:n_data_sets, function(x) explore(as.matrix(subset(Y, .imp == x)[,!(names(Y) %in% ".imp")]),
                                                       iter = iter,
                                                       impute = FALSE, ...))
 
@@ -160,7 +160,7 @@ bggm_missing <- function(x, iter = 2000,
   if(method == "estimate"){
 
     # fit the models
-    fits <- lapply(1:n_data_sets, function(x) estimate(as.matrix(subset(Y, .imp == x)[,-1]),
+    fits <- lapply(1:n_data_sets, function(x) estimate(as.matrix(subset(Y, .imp == x)[,!(names(Y) %in% ".imp")]),
                                                        iter = iter,
                                                        impute = FALSE, ...))
 


### PR DESCRIPTION
For me removing the .imp column by index was not working since in my imputed datasets .imp column was appended as the last column and not first. Removing it by name seems to be a more robust solution that worked for me.

Let me know what you think!